### PR TITLE
Fix collision mass for non-catastrophic collision case

### DIFF
--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -28,7 +28,7 @@ void Breakup::run() {
 
 Breakup &Breakup::setSeed(std::optional<unsigned long> seed) {
     if (seed.has_value()) {
-        _fixRNG = std::mt19937(seed.value());
+        _fixRNG = std::mt19937 {seed.value()};
     } else {
         _fixRNG = std::nullopt;
     }

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -28,7 +28,7 @@ void Breakup::run() {
 
 Breakup &Breakup::setSeed(std::optional<unsigned long> seed) {
     if (seed.has_value()) {
-        _fixRNG = std::mt19937 {seed.value()};
+        _fixRNG = std::mt19937(seed.value());
     } else {
         _fixRNG = std::nullopt;
     }


### PR DESCRIPTION
# Changelog

- Adopted the correct formula for determining the collision mass in the non-catastrophic case (Use correct exponent 2)
- This was wrong in the original publication [1], as [2] states
- The correct formula uses the squared impact velocity


[1] Johnson, N. L., Krisko, P. H., Liou, J. C., & Anz-Meador, P. D. (2001). NASA's new breakup model of EVOLVE 4.0. Advances in Space Research, 28(9), 1377-1384.

[2] Horstman, A. (2020). Enhancement of s/c Fragmentation and Environment Evolution Models. Final Report, Contract N. 4000115973/15/D/SR, Institute of Space System, Technische Universität Braunschweig, 26(08).
