### PR TITLE
Non-catastrophic Remnant

### DIFF
--- a/src/breakupModel/model/Satellites.cpp
+++ b/src/breakupModel/model/Satellites.cpp
@@ -67,3 +67,18 @@ std::tuple<double &, double &, double &, double &> Satellites::appendElement() {
             {characteristicLength.back(), areaToMassRatio.back(), area.back(), mass.back()};
 }
 
+std::tuple<double &, double &, double &, double &> Satellites::prependElement() {
+    this->resize(this->size() + 1);
+
+    std::swap(name.front(), name.back());
+    std::swap(characteristicLength.front(), characteristicLength.back());
+    std::swap(areaToMassRatio.front(), areaToMassRatio.back());
+    std::swap(mass.front(), mass.back());
+    std::swap(area.front(), area.back());
+    std::swap(ejectionVelocity.front(), ejectionVelocity.back());
+    std::swap(velocity.front(), velocity.back());
+
+    return std::tuple<double &, double &, double &, double &>
+            {characteristicLength.front(), areaToMassRatio.front(), area.front(), mass.front()};
+}
+

--- a/src/breakupModel/model/Satellites.h
+++ b/src/breakupModel/model/Satellites.h
@@ -159,4 +159,11 @@ public:
      */
     std::tuple<double &, double &, double &, double &> appendElement();
 
+    /**
+     * This resizes the Structure by one additional Slot and returns references to the
+     * characteristic length, area-mass-ratio, area and mass of the new element.
+     * @return tuple of references to characteristic length, area-mass-ratio, area and mass
+     */
+    std::tuple<double &, double &, double &, double &> prependElement();
+
 };

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -28,7 +28,7 @@ void Breakup::run() {
 
 Breakup &Breakup::setSeed(std::optional<unsigned long> seed) {
     if (seed.has_value()) {
-        _fixRNG = std::mt19937(seed.value());
+        _fixRNG = std::mt19937 {seed.value()};
     } else {
         _fixRNG = std::nullopt;
     }

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -73,24 +73,23 @@ void Breakup::enforceMassConservation() {
     spdlog::debug("The simulation produced {} kg of debris", _outputMass);
     size_t oldSize = _output.size();
     size_t newSize = _output.size();
+    // Shrink and Remove Mass Excess
     while (_outputMass > _inputMass) {
         _outputMass -= _output.mass.back();
         newSize -= 1;
         _output.mass.pop_back();
     }
-    if (oldSize != newSize) {
-        spdlog::warn("The simulation reduced the number of fragments because the mass budget was exceeded. "
-                     "In other words: The random behaviour has produced heavier fragments");
-        spdlog::warn("The fragment count was reduced from {} to {} fragments.", oldSize, newSize);
-        spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
-        _output.resize(newSize);
-    } else if (_enforceMassConservation) {
-        //This is written in an else if, because if the former condition was true, we already had too many fragments
-        //But we only need to check this here when no fragments had to be removed.
+    _output.resize(newSize);
+
+    // Add new Fragments to better fulfill the Mass Budget
+    if (_enforceMassConservation) {
         this->addFurtherFragments();
         newSize = _output.size();
-        spdlog::warn("The simulation increased the number of fragments to enforce the mass conservation.");
-        spdlog::warn("The fragment count was increased from {} to {} fragments.", oldSize, newSize);
+    }
+    // Some helpful logging hints
+    if (oldSize != newSize) {
+        spdlog::warn("The simulation modified the number of fragments to enforce the mass conservation.");
+        spdlog::warn("The fragment count was adapted from {} to {} fragments.", oldSize, newSize);
         spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
     }
 }

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -81,8 +81,8 @@ void Breakup::enforceMassConservation() {
     }
     _output.resize(newSize);
 
-    // Add new Fragments to better fulfill the Mass Budget
-    if (_enforceMassConservation) {
+    // Add new Fragments to better fulfill the Mass Budget, if mass excess was not already removed
+    if (_enforceMassConservation && newSize == oldSize) {
         this->addFurtherFragments();
         newSize = _output.size();
     }

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -69,7 +69,7 @@ void Breakup::areaToMassRatioDistribution() {
 void Breakup::enforceMassConservation() {
     //Enforce Mass Conservation if the output mass is greater than the input mass
     _outputMass = std::reduce(std::execution::par_unseq,_output.mass.begin(), _output.mass.end(), 0.0);
-    spdlog::debug("The simulation got {} kg of input mass", _inputMass);
+    spdlog::debug("The simulation got {} kg of input mass for fragments", _inputMass);
     spdlog::debug("The simulation produced {} kg of debris", _outputMass);
     size_t oldSize = _output.size();
     size_t newSize = _output.size();
@@ -87,27 +87,31 @@ void Breakup::enforceMassConservation() {
     } else if (_enforceMassConservation) {
         //This is written in an else if, because if the former condition was true, we already had too many fragments
         //But we only need to check this here when no fragments had to be removed.
-        while (_outputMass < _inputMass) {
-            //Order in the tuple: 0: L_c | 1: A/M | 2: Area | 3: Mass
-            //Create new element and assign values
-            auto tuple = _output.appendElement();
-            auto &[lc, areaToMassRatio, area, mass] = tuple;
-            lc = calculateCharacteristicLength();
-            areaToMassRatio = calculateAreaMassRatio(lc);
-            area = calculateArea(lc);
-            mass = calculateMass(area, areaToMassRatio);
-
-            //Calculate new mass
-            _outputMass += mass;
-        }
-        //Remove the element which has lead to the exceeding of the mass budget
-        _outputMass -= _output.mass.back();
-        _output.popBack();
+        this->addFurtherFragments();
         newSize = _output.size();
         spdlog::warn("The simulation increased the number of fragments to enforce the mass conservation.");
         spdlog::warn("The fragment count was increased from {} to {} fragments.", oldSize, newSize);
         spdlog::debug("The simulation corrected to {} kg of debris", _outputMass);
     }
+}
+
+void Breakup::addFurtherFragments() {
+    while (_outputMass < _inputMass) {
+        //Order in the tuple: 0: L_c | 1: A/M | 2: Area | 3: Mass
+        //Create new element and assign values
+        auto tuple = _output.appendElement();
+        auto &[lc, areaToMassRatio, area, mass] = tuple;
+        lc = calculateCharacteristicLength();
+        areaToMassRatio = calculateAreaMassRatio(lc);
+        area = calculateArea(lc);
+        mass = calculateMass(area, areaToMassRatio);
+
+        //Calculate new mass
+        _outputMass += mass;
+    }
+    //Remove the element which has lead to the exceeding of the mass budget
+    _outputMass -= _output.mass.back();
+    _output.popBack();
 }
 
 void Breakup::deltaVelocityDistribution() {

--- a/src/breakupModel/simulation/Breakup.cpp
+++ b/src/breakupModel/simulation/Breakup.cpp
@@ -28,7 +28,7 @@ void Breakup::run() {
 
 Breakup &Breakup::setSeed(std::optional<unsigned long> seed) {
     if (seed.has_value()) {
-        _fixRNG = std::mt19937 {seed.value()};
+        _fixRNG = std::mt19937(seed.value());
     } else {
         _fixRNG = std::nullopt;
     }

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -218,6 +218,8 @@ protected:
      */
     void enforceMassConservation();
 
+    virtual void addFurtherFragments();
+
     /**
      * This Method does assign each fragment a parent (trivial in Explosion case) and checks that
      * the step before did not produce more mass than the input contained if so warning is printed
@@ -234,8 +236,6 @@ protected:
      * The subclasses therefore init _deltaVelocityFactorOffset differently.
      */
     void deltaVelocityDistribution();
-
-private:
 
     /**
      * This Method calculates one characteristic Length for one Debris Particle.
@@ -261,6 +261,7 @@ private:
      */
     static double calculateArea(double characteristicLength);
 
+
     /**
      * Calculates the Mass for one fragment.
      * This method uses equation (10) from the the NASA Breakup Model Paper.
@@ -269,7 +270,6 @@ private:
      * @return Mass in [kg]
      */
     static double calculateMass(double area, double areaMassRatio);
-
 
     /**
      * Transforms a scalar velocity into a 3-dimensional cartesian velocity vector.

--- a/src/breakupModel/simulation/Breakup.h
+++ b/src/breakupModel/simulation/Breakup.h
@@ -218,6 +218,11 @@ protected:
      */
     void enforceMassConservation();
 
+    /**
+     * This generates fragments if outputMass > inputMass
+     * This method is called by enforceMassConservation() and overriden in the Collision subclass since the
+     * non-catastrophic collision has a special treatment due to the remaining cratered target satellite
+     */
     virtual void addFurtherFragments();
 
     /**

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -64,24 +64,25 @@ void Collision::calculateFragmentCount() {
 }
 
 void Collision::addFurtherFragments() {
-    if (_isCatastrophic) {
-        // If catastrophic: continue filling with more fragments according to L_c power law
-        Breakup::addFurtherFragments();
-    } else {
+    if (!_isCatastrophic) {
         // If non-catastrophic: add a remainder fragment
+        Satellite &target = _input.at(0);
+
         // Prepend, so that the bigger satellite (target) is assigned as parent
         auto tuple = _output.prependElement();
         auto &[lc, areaToMassRatio, area, mass] = tuple;
 
         // One special fragment representing the cratered remainder of the target satellite hit by the projectile
-        mass = _inputMass - _outputMass;
+        // However, it should not be heavier than the actual original parent!
+        mass = std::min(_inputMass - _outputMass, target.getMass());
         lc = util::calculateCharacteristicLengthFromMass(mass);
         areaToMassRatio = calculateAreaMassRatio(lc);
         area = calculateArea(lc);
 
         // Update the output mass accordingly
-        _outputMass = _inputMass;
+        _outputMass += mass;
     }
+    Breakup::addFurtherFragments();
 }
 
 void Collision::assignParentProperties() {

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -29,6 +29,12 @@ void Collision::calculateFragmentCount() {
         std::swap(sat1, sat2);
     }
 
+    //Sets the _input mass which will be required later for mass conservation purpose (maximal upper bound)
+    _inputMass = sat1.getMass() + sat2.getMass();
+
+    //Contains the mass M (later filled with an adequate value)
+    double mass = 0;
+
     //The Relative Collision Velocity [m/s]
     const double dv = euclideanNorm(sat1.getVelocity() - sat2.getVelocity());
     // Squared Relative Collision Velocity [m^2/s^2]
@@ -45,38 +51,36 @@ void Collision::calculateFragmentCount() {
         // Horstman, A. (2020). Enhancement of s/c Fragmentation and Environment Evolution Models.
         // Final Report, Contract N. 4000115973/15/D/SR,
         // Institute of Space System, Technische Universität Braunschweig, 26(08).
-        _inputMass = sat2.getMass() * dv2 / 1e6;
+        mass = sat2.getMass() * dv2 / 1e6;
     } else {
         _isCatastrophic = true;
-        _inputMass = sat1.getMass() + sat2.getMass();
+        mass = sat1.getMass() + sat2.getMass();
     }
 
     //The fragment Count, respectively Equation 4
-    auto fragmentCount = static_cast<size_t>(0.1 * std::pow(_inputMass, 0.75) *
+    auto fragmentCount = static_cast<size_t>(0.1 * std::pow(mass, 0.75) *
                                              std::pow(_minimalCharacteristicLength, -1.71));
     this->generateFragments(fragmentCount, sat1.getPosition());
 }
 
 void Collision::addFurtherFragments() {
-    Breakup::addFurtherFragments();
-    // If not catastrophic, add a remainder fragment
-    if (!_isCatastrophic) {
-        Satellite &sat1 = _input.at(0);
-        Satellite &sat2 = _input.at(1);
-        const double totalMass = sat1.getMass() + sat2.getMass();
-
+    if (_isCatastrophic) {
+        // If catastrophic: continue filling with more fragments according to L_c power law
+        Breakup::addFurtherFragments();
+    } else {
+        // If non-catastrophic: add a remainder fragment
         // Prepend, so that the bigger satellite (target) is assigned as parent
         auto tuple = _output.prependElement();
         auto &[lc, areaToMassRatio, area, mass] = tuple;
 
         // One special fragment representing the cratered remainder of the target satellite hit by the projectile
-        mass = totalMass - _inputMass;
+        mass = _inputMass - _outputMass;
         lc = util::calculateCharacteristicLengthFromMass(mass);
         areaToMassRatio = calculateAreaMassRatio(lc);
         area = calculateArea(lc);
 
-        // Later relevant for assignParentProperties!
-        _inputMass = totalMass;
+        // Update the output mass accordingly
+        _outputMass = _inputMass;
     }
 }
 

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -65,7 +65,8 @@ void Collision::addFurtherFragments() {
         Satellite &sat2 = _input.at(1);
         const double totalMass = sat1.getMass() + sat2.getMass();
 
-        auto tuple = _output.appendElement();
+        // Prepend, so that the bigger satellite (target) is assigned as parent
+        auto tuple = _output.prependElement();
         auto &[lc, areaToMassRatio, area, mass] = tuple;
 
         // One special fragment representing the cratered remainder of the target satellite hit by the projectile
@@ -73,6 +74,9 @@ void Collision::addFurtherFragments() {
         lc = util::calculateCharacteristicLengthFromMass(mass);
         areaToMassRatio = calculateAreaMassRatio(lc);
         area = calculateArea(lc);
+
+        // Later relevant for assignParentProperties!
+        _inputMass = totalMass;
     }
 }
 

--- a/src/breakupModel/simulation/Collision.cpp
+++ b/src/breakupModel/simulation/Collision.cpp
@@ -29,9 +29,9 @@ void Collision::calculateFragmentCount() {
         std::swap(sat1, sat2);
     }
 
-    //The Relative Collision Velocity
+    //The Relative Collision Velocity [m/s]
     const double dv = euclideanNorm(sat1.getVelocity() - sat2.getVelocity());
-    // Squared Relative Collision Velocity
+    // Squared Relative Collision Velocity [m^2/s^2]
     const double dv2 = dv * dv;
 
     //Calculate the Catastrophic Ratio, if greater than 40 J/g then we have a catastrophic collision
@@ -45,7 +45,7 @@ void Collision::calculateFragmentCount() {
         // Horstman, A. (2020). Enhancement of s/c Fragmentation and Environment Evolution Models.
         // Final Report, Contract N. 4000115973/15/D/SR,
         // Institute of Space System, Technische Universität Braunschweig, 26(08).
-        _inputMass = sat2.getMass() * dv2 / 1000.0;
+        _inputMass = sat2.getMass() * dv2 / 1e6;
     } else {
         _isCatastrophic = true;
         _inputMass = sat1.getMass() + sat2.getMass();

--- a/src/breakupModel/simulation/Collision.h
+++ b/src/breakupModel/simulation/Collision.h
@@ -22,6 +22,9 @@ private:
 
     void assignParentProperties() final;
 
+protected:
+    void addFurtherFragments() override;
+
 public:
 
     bool isIsCatastrophic() const {

--- a/test/simulation/NonCatastrophicCollisionTest.cpp
+++ b/test/simulation/NonCatastrophicCollisionTest.cpp
@@ -1,0 +1,137 @@
+#include "gtest/gtest.h"
+
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include "breakupModel/model/Satellite.h"
+#include "breakupModel/model/SatelliteBuilder.h"
+#include "breakupModel/simulation/Collision.h"
+
+class NonCatastrophicCollisionTest : public ::testing::Test {
+
+protected:
+
+    virtual void SetUp() {
+        SatelliteBuilder satelliteBuilder{};
+        sat1 = satelliteBuilder
+                .setID(24946)
+                .setName("Iridium 33")
+                .setSatType(SatType::SPACECRAFT)
+                .setMass(560)
+                .setVelocity({100.0, 0.0, 0.0})
+                .getResult();
+        sat2 = satelliteBuilder
+                .setID(22675)
+                .setName("Kosmos 2251")
+                .setSatType(SatType::SPACECRAFT)
+                .setMass(950)
+                .setVelocity({0, 0.0, 0.0})
+                .getResult();
+
+        _input.push_back(sat1);
+        _input.push_back(sat2);
+
+
+        _collision = std::make_unique<Collision>(_input, _minimalCharacteristicLength);
+    }
+
+    std::vector<Satellite> _input{};
+
+    Satellite sat1;
+    Satellite sat2;
+
+    double _minimalCharacteristicLength{0.05};
+
+    std::unique_ptr<Collision> _collision;
+
+};
+
+
+TEST_F(NonCatastrophicCollisionTest, FragmentCountTest) {
+    _collision->setSeed(std::make_optional(8)).run();
+    auto output = _collision->getResult();
+
+    ASSERT_FALSE(_collision->isIsCatastrophic()) << "This collision was non-catastrophic";
+
+    size_t expectedFragmentCount = 61;
+
+    ASSERT_EQ(output.size(), expectedFragmentCount);
+}
+
+TEST_F(NonCatastrophicCollisionTest, CheckRemnant) {
+    _collision = std::make_unique<Collision>(_input, _minimalCharacteristicLength, 0, true);
+    _collision->setSeed(std::make_optional(8)).run();
+    auto output = _collision->getResult();
+
+    ASSERT_FALSE(_collision->isIsCatastrophic()) << "This collision was non-catastrophic";
+
+    size_t expectedFragmentCount = 62;
+
+    ASSERT_EQ(output.size(), expectedFragmentCount);
+
+    // The Remnant
+    ASSERT_NEAR(output[0].getMass(), 1505.0, 1.0);
+}
+
+
+TEST_F(NonCatastrophicCollisionTest, FragmentSizeDsitributionTest) {
+    using namespace util;
+    _collision->setSeed(std::make_optional(10)).run();
+    auto output = _collision->getResult();
+
+    double Lc1 = sat1.getCharacteristicLength();
+    double Lc2 = sat2.getCharacteristicLength();
+    double expectedMaximalCharacteristicLength = Lc1 > Lc2 ? Lc1 : Lc2;
+
+    ASSERT_FLOAT_EQ(_collision->getMaximalCharacteristicLength(), expectedMaximalCharacteristicLength);
+
+    double Lc = _minimalCharacteristicLength;
+
+    //10% Deviation for the Test Case (--> +-6 Fragments)
+    double deviation = static_cast<double>(output.size()) * 0.1;
+
+    while(Lc < expectedMaximalCharacteristicLength) {
+        size_t count = std::count_if(output.begin(), output.end(),[Lc](Satellite &sat) {
+            return sat.getCharacteristicLength() > Lc;
+        });
+
+        const double dv = euclideanNorm(sat1.getVelocity() - sat2.getVelocity());
+        const double dv2 = dv * dv;
+
+        double expectedCount = 0.1 * std::pow(sat1.getMass() * dv2 / 1e6, 0.75) * std::pow(Lc, -1.71);
+
+        size_t expectedUpperBound = static_cast<size_t>(expectedCount + deviation);
+        size_t expectedLowerBound = expectedCount - deviation > 0 ? static_cast<size_t>(expectedCount - deviation) : 0;
+
+        ASSERT_GE(count, expectedLowerBound) << "L_c was " << Lc;
+        ASSERT_LE(count, expectedUpperBound) << "L_c was " << Lc;
+
+        Lc += 0.1;
+    }
+}
+
+TEST_F(NonCatastrophicCollisionTest, CheckNoRaceCondition) {
+    for (size_t x = 0; x < 50; ++x) {
+        size_t count = 0;
+        _collision->run();
+        auto output = _collision->getResultSoA();
+        for (double lc1 : output.characteristicLength) {
+            for (double lc2 : output.characteristicLength) {
+                bool condition = std::abs(lc1 - lc2) < 1e-16;
+                if (condition) {
+                    count += 1;
+                }
+            }
+        }
+        count -= output.characteristicLength.size();
+        //10 is threshold
+        //If we would have race conditions, it can be assumed that there are a lot more than 10 duplicates
+        EXPECT_LT(count, 10) << "Count of Duplicates in Iteration " << x << "\n"
+        << "If this test fails this not necessarily bad. This checks if we have any duplicates in the L_c set.\n"
+           "If there are any, this might be an issue and a hint for a race condition but not necessarily\n"
+           "It could also be just a random coincidence of the RNG\n"
+           "Rerun this in such a case!\n";
+    }
+}

--- a/test/simulation/NonCatastrophicCollisionTest.cpp
+++ b/test/simulation/NonCatastrophicCollisionTest.cpp
@@ -67,12 +67,8 @@ TEST_F(NonCatastrophicCollisionTest, CheckRemnant) {
 
     ASSERT_FALSE(_collision->isIsCatastrophic()) << "This collision was non-catastrophic";
 
-    size_t expectedFragmentCount = 62;
-
-    ASSERT_EQ(output.size(), expectedFragmentCount);
-
     // The Remnant
-    ASSERT_NEAR(output[0].getMass(), 1505.0, 1.0);
+    ASSERT_DOUBLE_EQ(output[0].getMass(), 950.0);
 }
 
 


### PR DESCRIPTION
# Changelog

## Overview

- Improves the mass conservation for non-catastrophic collision by adding a fragment representing the cratered target (which was hit by the projectile)
- The syntax has been changed to avoid unnecessary copies (new method `addFurtherFragments()`). This method adds fragments until the collision mass (not total involved mass) has been reached (ergo: no change for catastrophic collisions, but a reasonable change for non-catastrophic collisions)
- A particular fragment is added at the end (for non-catastrophic collisions), filling the remaining mass
- **The changes only affect non-catastrophic collisions if and only if mass conservation is enabled**
- #4 needs to be merged first!
- #4 actually introduced a bug. Due to the squared impact velocity, we need to divide by `1e6` not `1e3` --> FIXED
- Slightly modified formula (remnant cannot be heavier than initial target satellite, would be weird if the collision of a 560kg and 950kg satellite yields a new 1500 kg satellite?!)
- Added test cases for non-catastrophic scenarios



## Comment

Generally, there is a wide variety of approaches available. Whereas the original publication does not mention mass conservation at all [1], other procedures fulfill mass conservation in a basic way of just regenerating fragments [2].

Both approaches have the advantage that the L_c distributions are not artificially changed. However, all models are empirical, so changes are always reasonable as the concrete strategy is based on the considered/ observed breakups.

[3] [4] [5] both propose some modifications. In the following, I stick to [3] with _implementation comments_:

- **Explosion Case**
  - Add 2-8 fragments greater than 1m
  - Rest follows the L_c power law
  - _not implemented because the normal L_c power law typically already produces approximately those numbers of fragments greater than 1m_
- **Non-catastrophic Collision Case**
  - 1 remnant object of mass (total_mass - collision_mass)
  - _implemented because this is a pretty reasonable assumption, improving mass conservation if enabled. However, if one additional constraint: the remnant object cannot be heavier than the actual target satellite!_
- **Catastrophic Collision Case**
  - Several Fragments greater than 1m
  - _not implemented since the more recent MASTER-8 [6] model assumes complete fragmentation. Therefore, we'll better stick with the base L_c distribution instead of enforcing "several" fragments_


## Sources

[1] Johnson, N. L., Krisko, P. H., Liou, J. C., & Anz-Meador, P. D. (2001). NASA's new breakup model of EVOLVE 4.0. Advances in Space Research, 28(9), 1377-1384.

[2] Bade, A., Jackson, A. A., Reynolds, R. C., Eichler, P., Krisko, P., Matney, M., ... & Johnson, N. L. (1998). Breakup model update at nasa/jsc. In 49th International Astronautical Congress.

[3] Krisko, P. H. (2011). Proper implementation of the 1998 NASA breakup model. Orbital Debris Quarterly News, 15(4), 1-10.

[4] Andrișan, R. L., Ioniță, A. G., González, R. D., Ortiz, N. S., Caballero, F. P., & Krag, H. (2017). Fragmentation event model and assessment tool (FREMAT) supporting on-orbit fragmentation analysis. In 7th European Conference on Space Debris.

[5] Radtke, J., Mueller, S., Schaus, V., & Stoll, E. (2017, April). LUCA2-an enhanced long-term utility for collision analysis. In Proceedings of the 7th European Conference on Space Debris. Darmstadt, Germany: ESA Space Debris Office.

[6] Horstman, A. (2020). Enhancement of s/c Fragmentation and Environment Evolution Models. Final Report, Contract N. 4000115973/15/D/SR, Institute of Space System, Technische Universität Braunschweig, 26(08).
